### PR TITLE
feat: modernize feature card styling and refine cost table

### DIFF
--- a/dashboard/src/components/CostTable.jsx
+++ b/dashboard/src/components/CostTable.jsx
@@ -6,17 +6,47 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TableFooter,
   Paper,
   Checkbox,
   Typography,
 } from '@mui/material'
 
 const services = [
-  { name: 'ChatGPT Plus (Agent Mode)', price: 20 },
-  { name: 'SaneBox or Compose AI', price: 10 },
-  { name: 'Call Assistant AI', price: 7 },
-  { name: 'Goodcall / Rosie / Allô', price: 50 },
-  { name: 'Meta AI (WhatsApp)', price: 0, defaultChecked: true, disabled: true },
+  {
+    name: 'ChatGPT Plus (Agent Mode)',
+    price: 20,
+    usedFor: [
+      'Email Assistant',
+      'Messaging',
+      'Groceries & To‑Do',
+      'Calendar & Scheduling',
+      'Cost Monitoring',
+      'Daily Briefing',
+    ],
+  },
+  {
+    name: 'SaneBox or Compose AI',
+    price: 10,
+    usedFor: ['Email Assistant'],
+  },
+  {
+    name: 'Call Assistant AI',
+    price: 7,
+    usedFor: ['Call Screening & Appointments'],
+  },
+  {
+    name: 'Goodcall / Rosie / Allô',
+    price: 50,
+    usedFor: ['Call Screening & Appointments'],
+  },
+  {
+    name: 'Meta AI (WhatsApp)',
+    price: 0,
+    defaultChecked: true,
+    disabled: true,
+    usedFor: ['Messaging'],
+  },
 ]
 
 function CostTable() {
@@ -44,6 +74,7 @@ function CostTable() {
           <TableRow>
             <TableCell>Service</TableCell>
             <TableCell>Price (€)</TableCell>
+            <TableCell>Used For</TableCell>
             <TableCell align="center">Subscribed</TableCell>
           </TableRow>
         </TableHead>
@@ -51,7 +82,13 @@ function CostTable() {
           {services.map((svc, idx) => (
             <TableRow key={svc.name}>
               <TableCell>{svc.name}</TableCell>
-              <TableCell>{svc.price}</TableCell>
+              <TableCell>
+                {svc.price.toLocaleString('en-IE', {
+                  style: 'currency',
+                  currency: 'EUR',
+                })}
+              </TableCell>
+              <TableCell>{svc.usedFor.join(', ')}</TableCell>
               <TableCell align="center">
                 <Checkbox
                   checked={selected[idx]}
@@ -63,11 +100,21 @@ function CostTable() {
             </TableRow>
           ))}
         </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell colSpan={3} align="right">
+              Total monthly cost:
+            </TableCell>
+            <TableCell align="center">
+              {total.toLocaleString('en-IE', {
+                style: 'currency',
+                currency: 'EUR',
+              })}
+            </TableCell>
+          </TableRow>
+        </TableFooter>
       </Table>
-      <Typography variant="subtitle1" align="right" sx={{ m: 2 }}>
-        Total monthly cost: €{total.toFixed(2)}
-      </Typography>
-      <Typography variant="caption" sx={{ ml: 2, display: 'block' }}>
+      <Typography variant="caption" sx={{ ml: 2, mt: 1, display: 'block' }}>
         <sup>*</sup> Meta AI features for WhatsApp are currently free where
         available.
       </Typography>

--- a/dashboard/src/components/FeatureCard.jsx
+++ b/dashboard/src/components/FeatureCard.jsx
@@ -16,6 +16,13 @@ function FeatureCard({ title, description, actions }) {
         display: 'flex',
         flexDirection: 'column',
         justifyContent: 'space-between',
+        borderRadius: 2,
+        boxShadow: 1,
+        transition: 'transform 0.2s, box-shadow 0.2s',
+        '&:hover': {
+          transform: 'translateY(-4px)',
+          boxShadow: 3,
+        },
       }}
     >
       <CardContent>
@@ -26,13 +33,21 @@ function FeatureCard({ title, description, actions }) {
           {description}
         </Typography>
       </CardContent>
-      <CardActions sx={{ mt: 'auto', flexWrap: 'wrap', gap: 1 }}>
+      <CardActions
+        sx={{
+          mt: 'auto',
+          flexWrap: 'wrap',
+          gap: 1,
+          flexDirection: { xs: 'column', sm: 'row' },
+        }}
+      >
         {actions.map(({ label, onClick }, idx) => (
           <Button
             key={idx}
             size="small"
             variant="contained"
             onClick={onClick}
+            sx={{ width: { xs: '100%', sm: 'auto' } }}
           >
             {label}
           </Button>

--- a/dashboard/src/components/__tests__/CostTable.test.jsx
+++ b/dashboard/src/components/__tests__/CostTable.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect } from 'vitest'
 import CostTable from '../CostTable'
@@ -8,13 +8,14 @@ describe('CostTable', () => {
   it('updates total when services are toggled', async () => {
     render(<CostTable />)
 
+    const totalRow = screen.getByText('Total monthly cost:').closest('tr')
     // Initially total should be 0
-    expect(screen.getByText(/Total monthly cost: €0.00/)).toBeInTheDocument()
+    expect(within(totalRow).getByText('€0.00')).toBeInTheDocument()
 
     const checkboxes = screen.getAllByRole('checkbox')
     // Toggle first checkbox (ChatGPT Plus - 20€)
     await userEvent.click(checkboxes[0])
 
-    expect(screen.getByText(/Total monthly cost: €20.00/)).toBeInTheDocument()
+    expect(within(totalRow).getByText('€20.00')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- refresh FeatureCard with rounded corners, shadows, and hover lift
- expand CostTable with feature usage, currency formatting, and totals in footer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a02cb6acfc832896886e10c8c8d434